### PR TITLE
Estilo vitrinas, ancho de filtro, ordenar por

### DIFF
--- a/store/blocks/search.jsonc
+++ b/store/blocks/search.jsonc
@@ -86,16 +86,13 @@
     "children": ["search-title.v2"]
   },
   "flex-layout.row#result": {
-    "children": ["flex-layout.col#filter", "flex-layout.col#content"],
-    "props": {
-      "preventHorizontalStretch": true,
-      "fullWidth": true
-    }
+    "children": ["flex-layout.col#filter", "flex-layout.col#content"]
   },
   "flex-layout.col#filter": {
     "children": ["filter-navigator.v3"],
     "props": {
-      "blockClass": "filterCol"
+      "blockClass": "filterCol",
+      "width": "20%"
     }
   },
   "flex-layout.col#content": {
@@ -106,23 +103,22 @@
       "flex-layout.row#fetchmore"
     ],
     "props": {
-      "width": "grow",
+      "width": "80%",
       "preventVerticalStretch": true
     }
   },
   "flex-layout.row#searchinfo": {
-    "children": ["flex-layout.col#productCount", "flex-layout.col#orderby"]
-  },
-  "flex-layout.col#productCount": {
-    "children": ["total-products.v2"],
+    "children": ["flex-layout.col#orderby"],
     "props": {
-      "blockClass": "productCountCol"
+      "horizontalAlign": "left"
     }
   },
   "flex-layout.col#orderby": {
     "children": ["order-by.v2"],
     "props": {
-      "blockClass": "orderByCol"
+      "blockClass": "orderByCol",
+      "horizontalAlign": "center",
+      "width": "30%"
     }
   },
   "flex-layout.row#fetchprevious": {

--- a/styles/css/vtex.product-price.css
+++ b/styles/css/vtex.product-price.css
@@ -1,0 +1,11 @@
+.installments--summary {
+    display: none!important;
+}
+
+.sellingPriceValue--summary {
+    font-weight: 800;
+    color: red;
+    font-size: 1em;
+    padding-left: 0;
+    padding-bottom: .3rem;
+}

--- a/styles/css/vtex.product-summary.css
+++ b/styles/css/vtex.product-summary.css
@@ -1,4 +1,4 @@
-/* .imageNormal.image {
+ .imageNormal.image {
     padding: 3rem 0;
     width: 100%;
     height: 100%;
@@ -66,14 +66,6 @@
 .price_listPriceLabel,
 .price_sellingPriceLabel {
     display: none !important;
-}
-
-.price_sellingPrice {
-    font-weight: 800;
-    color: red;
-    font-size: 1em;
-    padding-left: 0;
-    padding-bottom: .3rem;
 }
 
 .price_listPrice {
@@ -145,11 +137,11 @@
 } 
  
 .skuSelectorSubcontainer--talla .skuSelectorItem .skuSelectorItemTextValue {
-    padding: .4rem .6rem;
+    padding: .4rem;
 } 
  
 @media (max-width: 991px) {
     .element :global(.vtex-button) { 
         opacity: 1 !important;
     } 
-} */
+}

--- a/styles/css/vtex.search-result.css
+++ b/styles/css/vtex.search-result.css
@@ -1,0 +1,23 @@
+.orderByText {
+    font-weight: 800;
+    color: #3f2016;
+}
+.orderByText::after {
+    content: ":";
+    display: inline-block;
+    font-size: 14px;
+}
+.orderByButton {
+    border: none;
+}
+.orderByOptionsContainer,
+.orderByOptionItem {
+    min-width: 180px;
+    max-width: 300px;
+    background-color: #f9f9f9;
+    font-family: 'Nunito', sans-serif;
+    font-size: 14px;
+}
+.orderByOptionItem:hover {
+    background: #ede3ce;
+}

--- a/styles/css/vtex.store-components.css
+++ b/styles/css/vtex.store-components.css
@@ -310,7 +310,7 @@
 } 
 
 .skuSelectorSubcontainer--talla .skuSelectorItem .skuSelectorItemTextValue {
-    padding: .4rem .6rem;
+    padding: .4rem;
 }
 
 


### PR DESCRIPTION
Se hicieron los siguientes ajustes a la PLP:

- Ordenar por: a la izquierda
- Estilo de vitrinas según maqueta
- Ancho de filtro según maqueta
- Se agregaron hojas de estilo (product-price.css, search-result.css)